### PR TITLE
fix: Address TypeScript and syntax errors (Round 3)

### DIFF
--- a/src/app/booking-payment-status/page.tsx
+++ b/src/app/booking-payment-status/page.tsx
@@ -162,13 +162,18 @@ function PaymentStatusContent() {
 
 export default function PaymentStatusPage() {
   return (
-    <Suspense fallback={
-      <div style={{ padding: '20px', textAlign: 'center', fontFamily: 'Arial, sans-serif', minHeight: '60vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
-        <h1 style={{ fontSize: '2em', marginBottom: '20px' }}>Loading Payment Details...</h1>
-        {/* Simple spinner or text */}
-        <p style={{ fontStyle: 'italic', color: '#777' }}>Please wait...</p>
-      </div>
-    }>
+    <Suspense
+      fallback={
+        <div style={{ padding: '20px', textAlign: 'center', fontFamily: 'Arial, sans-serif', minHeight: '60vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
+          <h1 style={{ fontSize: '2em', marginBottom: '20px' }}>
+            Loading Payment Details...
+          </h1>
+          <p style={{ fontStyle: 'italic', color: '#777' }}>
+            Please wait...
+          </p>
+        </div>
+      }
+    >
       <PaymentStatusContent />
     </Suspense>
   );


### PR DESCRIPTION
I've made further attempts to resolve remaining errors in the PhonePe integration files:

1.  **`src/app/api/bookings/check-payment-status/route.ts`:**
    *   I defined and applied the `PhonePeCheckStatusApiResponse` interface to the JSON response from PhonePe's Check Status API. This should resolve multiple `ts(18046)` 'unknown' type errors for the `phonePeStatusResponse` variable.

2.  **`src/app/booking-payment-status/page.tsx`:**
    *   I addressed persistent syntax errors ("expression not callable" and "unterminated template literal") reported around line 176 by re-typing the `Suspense` component block in that area. This is an attempt to eliminate potential hidden characters or subtle syntax issues.
    *   Previous fixes in this file (defining and applying `CheckStatusResponse` for the API call made by this page) are maintained to address 'unknown' type errors for fetched data.

These changes aim to further stabilize the type safety and syntax of the PhonePe integration code.