### PR TITLE
Fix: Correct booking confirmation display for package category and phone

### DIFF
--- a/src/app/(main)/booking/confirmation/[bookingId]/page.tsx
+++ b/src/app/(main)/booking/confirmation/[bookingId]/page.tsx
@@ -28,7 +28,7 @@ interface BookingData {
   totalPeople?: number;
   guestName?: string | null;
   guestEmail?: string | null;
-  guestMobile?: string | null;
+  guestPhone?: string | null;
   specialRequests?: string | null;
 
   // Assuming relational data is included by the API:
@@ -76,6 +76,8 @@ function BookingConfirmationContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // TODO: Implement booking download as PDF functionality
+  // TODO: Implement sending booking details mail to the user functionality
   useEffect(() => {
     if (!bookingId) {
       setError("Booking ID is missing from the URL.");
@@ -101,6 +103,7 @@ function BookingConfirmationContent() {
           throw new Error(errorMessage);
         }
         const data: BookingData = await response.json();
+        console.log('Fetched booking data:', data);
         setBooking(data);
       } catch (err: any) {
         console.error("Fetch booking error:", err);
@@ -248,7 +251,7 @@ function BookingConfirmationContent() {
                   <div className="space-y-1 text-sm">
                     <p><strong>Name:</strong> {booking.user?.name || booking.guestName || 'N/A'}</p>
                     <p><strong>Email:</strong> {booking.user?.email || booking.guestEmail || 'N/A'}</p>
-                    <p><strong>Phone:</strong> {booking.guestMobile || 'N/A'}</p>
+                    <p><strong>Phone:</strong> {booking.guestPhone || 'N/A'}</p>
                   </div>
                 </section>
 

--- a/src/app/api/bookings/[bookingId]/route.ts
+++ b/src/app/api/bookings/[bookingId]/route.ts
@@ -49,7 +49,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
       // Nested related data based on aliased names from the SQL query
       package: bookingFromDb.packageName ? { name: bookingFromDb.packageName } : undefined,
-      packageCategory: bookingFromDb.packageCategoryName ? { category_name: bookingFromDb.packageCategoryName } : undefined,
+      packageCategory: bookingFromDb.packageCategoryName ? { name: bookingFromDb.packageCategoryName } : undefined,
       user: (bookingFromDb.userEmail || bookingFromDb.userFirstName || bookingFromDb.userLastName) // Check if any user detail is present
         ? { 
             name: [bookingFromDb.userFirstName, bookingFromDb.userLastName].filter(Boolean).join(' ').trim() || undefined, 


### PR DESCRIPTION
- API: I modified `src/app/api/bookings/[bookingId]/route.ts` to map package category name to `packageCategory.name` (was `category_name`) for frontend consistency.
- Frontend: I updated `src/app/(main)/booking/confirmation/[bookingId]/page.tsx`'s `BookingData` interface to expect `guestPhone` instead of `guestMobile`.
- Frontend: I updated rendering logic in the booking confirmation page to use `booking.guestPhone`.
- Frontend: I added `console.log` in booking confirmation page to output fetched booking data for easier debugging by developers.

- Verification: I confirmed that `src/lib/database.ts` correctly selects `guest_phone` and user details, and the API route makes them available. If `guestPhone` still displays as 'N/A', the `guest_phone` column in the `bookings` table for the specific booking should be inspected as it's likely NULL or empty.