### PR TITLE
feat: Overhaul admin approvals page for status management

### DIFF
--- a/src/app/api/admin/approvals/route.ts
+++ b/src/app/api/admin/approvals/route.ts
@@ -63,9 +63,9 @@ export async function GET(request: NextRequest) {
     if (!type || type === 'all') {
       // For "all", we need to fetch each type separately then combine
       const [hotelsResult, hotelRoomsResult, servicesResult] = await Promise.all([
-        dbService.getUnapprovedHotels(limit, offset),
-        dbService.getUnapprovedHotelRooms(limit, offset),
-        dbService.getUnapprovedServices(limit, offset)
+        dbService.getAllHotelsForAdminStatusPage(limit, offset), // Updated
+        dbService.getAllHotelRoomsForAdminStatusPage(limit, offset), // Updated
+        dbService.getAllOtherServicesForAdminStatusPage(limit, offset) // Updated
       ]);
       
       // Combine results
@@ -77,9 +77,9 @@ export async function GET(request: NextRequest) {
       
       // Get total count for pagination
       const [hotelCount, roomCount, serviceCount] = await Promise.all([
-        dbService.countUnapprovedHotels(),
-        dbService.countUnapprovedHotelRooms(),
-        dbService.countUnapprovedServices()
+        dbService.countAllHotelsForAdminStatusPage(), // Updated
+        dbService.countAllHotelRoomsForAdminStatusPage(), // Updated
+        dbService.countAllOtherServicesForAdminStatusPage() // Updated
       ]);
       
       total = (hotelCount?.total || 0) + (roomCount?.total || 0) + (serviceCount?.total || 0);
@@ -96,23 +96,23 @@ export async function GET(request: NextRequest) {
       // Handle specific type filter
       switch (type) {
         case 'hotels':
-          const hotelsResult = await dbService.getUnapprovedHotels(limit, offset);
+          const hotelsResult = await dbService.getAllHotelsForAdminStatusPage(limit, offset); // Updated
           items = (hotelsResult.results || []).map(h => ({ ...h, type: 'hotel' }));
-          const hotelCount = await dbService.countUnapprovedHotels();
+          const hotelCount = await dbService.countAllHotelsForAdminStatusPage(); // Updated
           total = hotelCount?.total || 0;
           break;
           
         case 'rooms':
-          const roomsResult = await dbService.getUnapprovedHotelRooms(limit, offset);
+          const roomsResult = await dbService.getAllHotelRoomsForAdminStatusPage(limit, offset); // Updated
           items = roomsResult.results || [];
-          const roomCount = await dbService.countUnapprovedHotelRooms();
+          const roomCount = await dbService.countAllHotelRoomsForAdminStatusPage(); // Updated
           total = roomCount?.total || 0;
           break;
           
         case 'services':
-          const servicesResult = await dbService.getUnapprovedServices(limit, offset);
+          const servicesResult = await dbService.getAllOtherServicesForAdminStatusPage(limit, offset); // Updated
           items = servicesResult.results || [];
-          const serviceCount = await dbService.countUnapprovedServices();
+          const serviceCount = await dbService.countAllOtherServicesForAdminStatusPage(); // Updated
           total = serviceCount?.total || 0;
           break;
           
@@ -132,7 +132,7 @@ export async function GET(request: NextRequest) {
     
     return NextResponse.json({
       success: true,
-      message: 'Pending approvals retrieved successfully',
+      message: 'Admin items retrieved successfully', // Updated message
       data: {
         items,
         pagination: {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -2009,4 +2009,89 @@ export class DatabaseService {
       return null; // Or throw, depending on desired error handling for the service layer
     }
   }
+
+  // --- Admin Status Page Methods ---
+
+  async getAllHotelsForAdminStatusPage(limit: number, offset: number): Promise<D1Result<any[]>> {
+    const db = await getDatabase();
+    return db
+      .prepare(
+        `SELECT
+           s.id, s.name, s.type, s.created_at, s.is_admin_approved, s.price, s.is_active,
+           h.star_rating
+         FROM services s
+         JOIN hotels h ON s.id = h.service_id
+         WHERE s.type = 'hotel'
+         ORDER BY s.created_at DESC
+         LIMIT ? OFFSET ?`
+      )
+      .bind(limit, offset)
+      .all();
+  }
+
+  async countAllHotelsForAdminStatusPage(): Promise<{ total: number } | null> {
+    const db = await getDatabase();
+    return db
+      .prepare(
+        `SELECT COUNT(*) as total
+         FROM services s
+         JOIN hotels h ON s.id = h.service_id
+         WHERE s.type = 'hotel'`
+      )
+      .first<{ total: number }>();
+  }
+
+  async getAllHotelRoomsForAdminStatusPage(limit: number, offset: number): Promise<D1Result<any[]>> {
+    const db = await getDatabase();
+    return db
+      .prepare(
+        `SELECT
+           hr.id, hr.room_type, hr.created_at, hr.is_admin_approved, hr.base_price as price_per_night,
+           hr.service_id AS hotel_service_id,
+           s.name AS hotel_name,
+           hr.is_active
+         FROM hotel_room_types hr
+         LEFT JOIN services s ON hr.service_id = s.id
+         ORDER BY hr.created_at DESC
+         LIMIT ? OFFSET ?`
+      )
+      .bind(limit, offset)
+      .all();
+  }
+
+  async countAllHotelRoomsForAdminStatusPage(): Promise<{ total: number } | null> {
+    const db = await getDatabase();
+    return db
+      .prepare(
+        `SELECT COUNT(*) as total
+         FROM hotel_room_types hr`
+      )
+      .first<{ total: number }>();
+  }
+
+  async getAllOtherServicesForAdminStatusPage(limit: number, offset: number): Promise<D1Result<any[]>> {
+    const db = await getDatabase();
+    return db
+      .prepare(
+        `SELECT
+           s.id, s.name, s.type, s.created_at, s.is_admin_approved, s.price, s.is_active
+         FROM services s
+         WHERE s.type NOT IN ('hotel')
+         ORDER BY s.created_at DESC
+         LIMIT ? OFFSET ?`
+      )
+      .bind(limit, offset)
+      .all();
+  }
+
+  async countAllOtherServicesForAdminStatusPage(): Promise<{ total: number } | null> {
+    const db = await getDatabase();
+    return db
+      .prepare(
+        `SELECT COUNT(*) as total
+         FROM services s
+         WHERE s.type NOT IN ('hotel')`
+      )
+      .first<{ total: number }>();
+  }
 }


### PR DESCRIPTION
This commit transforms the `/admin/admin_approvals` page from a list of items pending initial approval into a comprehensive tool for managing the approval status (Pending, Approved, Rejected) of all services, hotels, and hotel rooms.

Key Changes:

1.  **DatabaseService Erweiterung (`src/lib/database.ts`):**
    *   I introduced new methods specifically for admin use:
        *   `getAllHotelsForAdminStatusPage` & `countAllHotelsForAdminStatusPage`
        *   `getAllHotelRoomsForAdminStatusPage` & `countAllHotelRoomsForAdminStatusPage`
        *   `getAllOtherServicesForAdminStatusPage` & `countAllOtherServicesForAdminStatusPage`
    *   These methods fetch all items regardless of their `is_admin_approved` or `is_active` status, include pagination, and select the `is_admin_approved` field.

2.  **API Endpoint Overhaul (`/api/admin/approvals/route.ts`):**
    *   The GET handler now uses the new `DatabaseService` methods to fetch all items (filtered by type: all, hotels, rooms, services) for the admin status management page, not just unapproved ones.
    *   The API response now includes all items with their current `is_admin_approved` status.
    *   The success message was updated to reflect this broader scope.

3.  **Frontend Update (`/admin/admin_approvals/page.tsx`):**
    *   I renamed the data fetching function (e.g., to `fetchAllItemsForStatusPage`) and updated it to use the overhauled API.
    *   A new "Status" column with styled badges (e.g., "Approved", "Pending/Rejected", "Pending") clearly displays the current `is_admin_approved` status for each item.
    *   I modified the `handleApprove` and `handleReject` functions:
        *   After successfully changing an item's status via API, they now re-fetch the entire list using `fetchAllItemsForStatusPage`. This ensures the item remains visible on the page with its updated status.
        *   I removed client-side filtering that previously removed items from the list upon action for this page's new purpose.
    *   Action buttons ("Approve", "Reject") are now rendered conditionally based on the item's current `is_admin_approved` status, allowing admins to toggle statuses.
    *   I updated the page title and other minor UI texts to reflect its new role as a status management page.
    *   I renamed the item interface from `UnapprovedItem` to `ManagedItem` and updated it.

This overhaul provides administrators with a centralized view to monitor and manage the approval lifecycle of all content items.