### PR TITLE
fix: Correct URL generation for activity previews in admin

### DIFF
--- a/src/app/(admin)/admin_approvals/page.tsx
+++ b/src/app/(admin)/admin_approvals/page.tsx
@@ -84,7 +84,7 @@ function AdminApprovalsContent() {
   ];
 
   // Renamed and hoisted function
-  const fetchAllItemsForStatusPage = async () => {
+  const fetchAllItemsForStatusPage = async () => { 
     setLoading(true);
     setError(null);
     try {
@@ -273,18 +273,19 @@ function AdminApprovalsContent() {
   const getViewUrl = (item: ManagedItem): string => { // Updated to ManagedItem
     let baseUrl = '#';
     const queryParams = '?isAdminPreview=true';
+    const normalizedItemType = getItemType(item); // Use the helper
 
-    if (item.room_type && item.hotel_service_id) {
-      // If it's a room, link to the parent hotel's page, and maybe an anchor to the room
+    if (normalizedItemType === 'room' && item.hotel_service_id) {
       baseUrl = `/hotels/${item.hotel_service_id}`;
-      // Optionally, you could try to add an anchor like #room-${item.id} if the hotel page supports it
-      // For now, just linking to the hotel page is sufficient for preview.
-    } else if (item.type === 'hotel') {
+    } else if (normalizedItemType === 'hotel') {
       baseUrl = `/hotels/${item.id}`;
-    } else if (item.type === 'activity') { // Specifically handle 'activity' type
+    } else if (normalizedItemType === 'activity') {
       baseUrl = `/activities/${item.id}`;
-    } else if (item.type) { // For other generic services (rental, transport, etc.)
-      baseUrl = `/services/${item.type}/${item.id}`;
+    } else if (item.type) { // For other types like 'rental', 'transport', use original item.type for the path
+      // Ensure normalizedItemType isn't 'item' (the fallback from getItemType) before constructing a /services/ URL
+      if (normalizedItemType !== 'item') {
+         baseUrl = `/services/${item.type}/${item.id}`;
+      }
     }
 
     return baseUrl === '#' ? baseUrl : baseUrl + queryParams;
@@ -298,10 +299,16 @@ function AdminApprovalsContent() {
     if (item.type === 'hotel') {
       return 'hotel';
     }
-    if (item.type) {
+    // Check if type starts with 'activity' (e.g., "activity/diving")
+    // and normalize it to 'activity' for routing purposes.
+    if (item.type && item.type.startsWith('activity')) { 
+      return 'activity';
+    }
+    // For other specific types like 'rental', 'transport'
+    if (item.type) { 
       return item.type;
     }
-    return 'item';
+    return 'item'; // Fallback
   };
 
   // Helper to get API type ID for the approval endpoint

--- a/src/app/(main)/hotels/[id]/page.tsx
+++ b/src/app/(main)/hotels/[id]/page.tsx
@@ -157,8 +157,8 @@ const HotelDetailPage = () => {
   if (selectedHotelError || (isAdminPreview && !rawHotelData?.success) || (!isAdminPreview && !selectedHotel && rawHotelData)) {
     // If it's admin preview and success is false, or if it's not admin and selectedHotel is not derived (but rawHotelData might exist with error)
     // This also covers cases where rawHotelData itself might be an error object from useFetch if the request failed fundamentally.
-    const message = selectedHotelError?.message ||
-                    (isAdminPreview && rawHotelData?.message) ||
+    const message = selectedHotelError?.message || 
+                    (isAdminPreview && rawHotelData?.message) || 
                     (!isAdminPreview && rawHotelData && !rawHotelData.id ? "Hotel data is not in expected format." : "Hotel details could not be found.");
     return <ErrorState message={message} onRetry={() => setRetryToken(c => c + 1)} />;
   }

--- a/src/app/api/admin/service_preview/[serviceId]/route.ts
+++ b/src/app/api/admin/service_preview/[serviceId]/route.ts
@@ -29,7 +29,7 @@ function parseStringList(value: string | null): string[] {
 function parseAmenities(amenitiesStr: string | null): any {
   if (!amenitiesStr) return { general: [], specifics: {} };
   try {
-    if ((amenitiesStr.trim().startsWith('{') && amenitiesStr.trim().endsWith('}')) ||
+    if ((amenitiesStr.trim().startsWith('{') && amenitiesStr.trim().endsWith('}')) || 
         (amenitiesStr.trim().startsWith('[') && amenitiesStr.trim().endsWith(']'))) {
       return JSON.parse(amenitiesStr);
     } else {
@@ -71,7 +71,7 @@ export async function GET(
       FROM services s
       LEFT JOIN islands i ON s.island_id = i.id  -- Changed to LEFT JOIN in case island_id is nullable or invalid temporarily
       LEFT JOIN service_providers sp ON s.provider_id = sp.id
-      WHERE s.id = ?
+      WHERE s.id = ? 
       AND (s.type LIKE 'transport%' OR s.type LIKE 'rental%' OR s.type LIKE 'activity%')
     `;
 
@@ -84,25 +84,25 @@ export async function GET(
         { status: 404 }
       );
     }
-
+    
     const parsedAmenities = parseAmenities(raw.amenities);
     const specificFields = parsedAmenities.specifics || {};
     const activitySpecifics = specificFields; // Assuming activity specifics might be directly under specifics
-
+    
     const locationDetails = specificFields.location_details || null;
     const whatToBring = specificFields.what_to_bring || [];
     const includedServices = specificFields.included_services || [];
     const notIncludedServices = specificFields.not_included_services || [];
     const latitude = specificFields.latitude ? parseFloat(specificFields.latitude) : null;
     const longitude = specificFields.longitude ? parseFloat(specificFields.longitude) : null;
-
+    
     const vehicleType = specificFields.vehicle_type || null;
     const capacityPassengers = specificFields.capacity_passengers ? parseInt(specificFields.capacity_passengers) : (specificFields.capacity ? parseInt(specificFields.capacity) : null);
     const routeDetails = specificFields.route_details || specificFields.route || null;
     const pricePerKm = specificFields.price_per_km ? parseFloat(specificFields.price_per_km) : null;
     const pricePerTrip = specificFields.price_per_trip ? parseFloat(specificFields.price_per_trip) : null;
     const driverIncluded = specificFields.driver_included === true;
-
+    
     const itemType = specificFields.item_type || null;
     const rentalDurationOptions = specificFields.rental_duration_options || [];
     const pricePerHour = specificFields.price_per_hour ? parseFloat(specificFields.price_per_hour) : null;
@@ -110,7 +110,7 @@ export async function GET(
     const depositAmount = specificFields.deposit?.amount ? parseFloat(specificFields.deposit.amount) : null;
     const pickupLocationOptions = specificFields.pickup_location_options || specificFields.pickup_locations || [];
     const rentalTerms = specificFields.rental_terms || specificFields.requirements?.details || null;
-
+    
     const providerInfo: ServiceProviderBasicInfo | undefined = raw.provider_business_name ? {
         id: raw.service_provider_table_id,
         business_name: raw.provider_business_name,

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -2047,10 +2047,10 @@ export class DatabaseService {
       .prepare(
         `SELECT
            hr.id, hr.room_type, hr.created_at, hr.is_admin_approved, hr.base_price as price_per_night,
-           hr.service_id AS hotel_service_id,
+           hr.service_id AS hotel_service_id, 
            s.name AS hotel_name
          FROM hotel_room_types hr
-         LEFT JOIN services s ON hr.service_id = s.id
+         LEFT JOIN services s ON hr.service_id = s.id 
          ORDER BY hr.created_at DESC
          LIMIT ? OFFSET ?`
       )
@@ -2075,7 +2075,7 @@ export class DatabaseService {
         `SELECT
            s.id, s.name, s.type, s.created_at, s.is_admin_approved, s.price, s.is_active
          FROM services s
-         WHERE s.type NOT IN ('hotel')
+         WHERE s.type NOT IN ('hotel') 
          ORDER BY s.created_at DESC
          LIMIT ? OFFSET ?`
       )


### PR DESCRIPTION
This commit resolves a 404 error that occurred when you attempted to view an activity with a sub-type (e.g., 'activity/diving') from the admin status management page (`/admin/admin_approvals`).

The fix involves changes in `src/app/(admin)/admin_approvals/page.tsx`:

1.  **Normalized Activity Type in `getItemType`:**
    *   I updated the `getItemType` helper function to normalize activity types. If an item's `type` field starts with "activity" (e.g., "activity/diving", "activity/tour"), the function now returns the base string "activity".

2.  **Updated `getViewUrl` to Use Normalized Type:**
    *   I modified the `getViewUrl` helper function to call `getItemType` to get the normalized item type.
    *   It then uses this normalized type for its routing logic. Specifically, if the normalized type is "activity", it correctly constructs the URL as `/activities/[id]?isAdminPreview=true`.

This ensures that all activity services, regardless of whether their `type` field includes a sub-category, are correctly routed to the `/activities/[id]` page structure for admin previews, preventing the 404 error.