### PR TITLE
fix: Ensure public listings only show admin-approved items

### DIFF
--- a/src/app/(admin)/admin_approvals/page.tsx
+++ b/src/app/(admin)/admin_approvals/page.tsx
@@ -84,7 +84,7 @@ function AdminApprovalsContent() {
   ];
 
   // Renamed and hoisted function
-  const fetchAllItemsForStatusPage = async () => { 
+  const fetchAllItemsForStatusPage = async () => {
     setLoading(true);
     setError(null);
     try {
@@ -301,11 +301,11 @@ function AdminApprovalsContent() {
     }
     // Check if type starts with 'activity' (e.g., "activity/diving")
     // and normalize it to 'activity' for routing purposes.
-    if (item.type && item.type.startsWith('activity')) { 
+    if (item.type && item.type.startsWith('activity')) {
       return 'activity';
     }
     // For other specific types like 'rental', 'transport'
-    if (item.type) { 
+    if (item.type) {
       return item.type;
     }
     return 'item'; // Fallback

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
   console.log('🔍 [API] GET /api/activities: Request received');
   try {
     console.log('🔍 [API] GET /api/activities: Attempting database connection...');
-    
+
     // First check if database connection works
     let db;
     try {
@@ -36,9 +36,9 @@ export async function GET(request: Request) {
       console.error('❌ [API] GET /api/activities: Database connection failed:', dbError);
       throw new Error(`Database connection failed: ${dbError instanceof Error ? dbError.message : String(dbError)}`);
     }
-    
+
     // await the D1Database instance
-    
+
     const { searchParams } = new URL(request.url);
     console.log('🔍 [API] GET /api/activities: Request URL:', request.url);
 
@@ -67,7 +67,7 @@ export async function GET(request: Request) {
         i.name AS island_name
       FROM services s
       JOIN islands i ON s.island_id = i.id
-      WHERE s.type LIKE ? AND s.is_active = TRUE` // Added s.is_active = TRUE
+      WHERE s.type LIKE ? AND s.is_active = TRUE AND s.is_admin_approved = 1` // Added s.is_admin_approved = 1
 
     const queryParams: (string | number)[] = ['%activity%']
 
@@ -88,7 +88,7 @@ export async function GET(request: Request) {
 
     const stmt = db.prepare(queryString).bind(...queryParams)
     console.log('🔍 [API] GET /api/activities: Executing query...');
-    
+
     let queryResult;
     try {
       queryResult = await stmt.all<Activity>();
@@ -97,7 +97,7 @@ export async function GET(request: Request) {
       console.error('❌ [API] GET /api/activities: Query execution failed:', queryError);
       throw new Error(`Query execution failed: ${queryError instanceof Error ? queryError.message : String(queryError)}`);
     }
-    
+
     const { results, success, error } = queryResult;
 
     console.log('🔍 [API] GET /api/activities: Query complete, success:', success);
@@ -109,7 +109,7 @@ export async function GET(request: Request) {
 
     const activitiesData = results ?? []
     console.log(`🔍 [API] GET /api/activities: Found ${activitiesData.length} activities`);
-    
+
     // Log each activity for debugging (limit to first 5 for brevity)
     const logLimit = Math.min(activitiesData.length, 5);
     for (let i = 0; i < logLimit; i++) {
@@ -124,13 +124,13 @@ export async function GET(request: Request) {
 
     if (activitiesData.length === 0) {
       console.warn('⚠️ [API] GET /api/activities: No activities found matching the criteria');
-      
+
       // Try a broader query to see if any services exist at all
       try {
         console.log('🔍 [API] GET /api/activities: Trying broader query to check if any services exist...');
         const checkServices = await db.prepare(`SELECT COUNT(*) as count FROM services`).first();
         console.log('🔍 [API] GET /api/activities: Services count:', checkServices);
-        
+
         if (checkServices && checkServices.count > 0) {
           console.log('🔍 [API] GET /api/activities: Services exist but no activities match the query criteria');
         } else {
@@ -159,10 +159,10 @@ export async function GET(request: Request) {
 
 
 export async function POST(request: NextRequest) {
-  
+
   console.warn("POST /api/activities is not fully implemented.");
    try {
-      
+
        return NextResponse.json({
            success: false, // Set to false as it's not implemented
            message: 'POST method for activities not implemented yet.',

--- a/src/app/api/admin/service_preview/[serviceId]/route.ts
+++ b/src/app/api/admin/service_preview/[serviceId]/route.ts
@@ -29,7 +29,7 @@ function parseStringList(value: string | null): string[] {
 function parseAmenities(amenitiesStr: string | null): any {
   if (!amenitiesStr) return { general: [], specifics: {} };
   try {
-    if ((amenitiesStr.trim().startsWith('{') && amenitiesStr.trim().endsWith('}')) || 
+    if ((amenitiesStr.trim().startsWith('{') && amenitiesStr.trim().endsWith('}')) ||
         (amenitiesStr.trim().startsWith('[') && amenitiesStr.trim().endsWith(']'))) {
       return JSON.parse(amenitiesStr);
     } else {
@@ -71,7 +71,7 @@ export async function GET(
       FROM services s
       LEFT JOIN islands i ON s.island_id = i.id  -- Changed to LEFT JOIN in case island_id is nullable or invalid temporarily
       LEFT JOIN service_providers sp ON s.provider_id = sp.id
-      WHERE s.id = ? 
+      WHERE s.id = ?
       AND (s.type LIKE 'transport%' OR s.type LIKE 'rental%' OR s.type LIKE 'activity%')
     `;
 
@@ -84,25 +84,25 @@ export async function GET(
         { status: 404 }
       );
     }
-    
+
     const parsedAmenities = parseAmenities(raw.amenities);
     const specificFields = parsedAmenities.specifics || {};
     const activitySpecifics = specificFields; // Assuming activity specifics might be directly under specifics
-    
+
     const locationDetails = specificFields.location_details || null;
     const whatToBring = specificFields.what_to_bring || [];
     const includedServices = specificFields.included_services || [];
     const notIncludedServices = specificFields.not_included_services || [];
     const latitude = specificFields.latitude ? parseFloat(specificFields.latitude) : null;
     const longitude = specificFields.longitude ? parseFloat(specificFields.longitude) : null;
-    
+
     const vehicleType = specificFields.vehicle_type || null;
     const capacityPassengers = specificFields.capacity_passengers ? parseInt(specificFields.capacity_passengers) : (specificFields.capacity ? parseInt(specificFields.capacity) : null);
     const routeDetails = specificFields.route_details || specificFields.route || null;
     const pricePerKm = specificFields.price_per_km ? parseFloat(specificFields.price_per_km) : null;
     const pricePerTrip = specificFields.price_per_trip ? parseFloat(specificFields.price_per_trip) : null;
     const driverIncluded = specificFields.driver_included === true;
-    
+
     const itemType = specificFields.item_type || null;
     const rentalDurationOptions = specificFields.rental_duration_options || [];
     const pricePerHour = specificFields.price_per_hour ? parseFloat(specificFields.price_per_hour) : null;
@@ -110,7 +110,7 @@ export async function GET(
     const depositAmount = specificFields.deposit?.amount ? parseFloat(specificFields.deposit.amount) : null;
     const pickupLocationOptions = specificFields.pickup_location_options || specificFields.pickup_locations || [];
     const rentalTerms = specificFields.rental_terms || specificFields.requirements?.details || null;
-    
+
     const providerInfo: ServiceProviderBasicInfo | undefined = raw.provider_business_name ? {
         id: raw.service_provider_table_id,
         business_name: raw.provider_business_name,

--- a/src/app/api/services-main/route.ts
+++ b/src/app/api/services-main/route.ts
@@ -100,7 +100,7 @@ export async function GET(request: NextRequest) {
       FROM services s
       JOIN islands i ON s.island_id = i.id
       LEFT JOIN service_providers sp ON s.provider_id = sp.id
-      WHERE s.is_active = TRUE
+      WHERE s.is_active = TRUE AND s.is_admin_approved = 1
     `;
 
     const queryParams: (string | number)[] = [];
@@ -284,4 +284,3 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(errorResponse, { status: 500 });
   }
 }
-

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1736,7 +1736,7 @@ export class DatabaseService {
       FROM services s
       JOIN hotels h ON s.id = h.service_id
       LEFT JOIN hotel_room_types hrt ON s.id = hrt.service_id -- LEFT JOIN to include hotels with no rooms
-      WHERE s.type = 'hotel' AND s.is_active = 1
+      WHERE s.type = 'hotel' AND s.is_active = 1 AND s.is_admin_approved = 1
     `;
     const params: (string | number)[] = [];
 
@@ -1820,7 +1820,7 @@ export class DatabaseService {
       SELECT COUNT(s.id) AS total
       FROM services s
       JOIN hotels h ON s.id = h.service_id
-      WHERE s.type = 'hotel' AND s.is_active = 1
+      WHERE s.type = 'hotel' AND s.is_active = 1 AND s.is_admin_approved = 1
     `;
     const params: (string | number)[] = [];
 
@@ -2047,10 +2047,10 @@ export class DatabaseService {
       .prepare(
         `SELECT
            hr.id, hr.room_type, hr.created_at, hr.is_admin_approved, hr.base_price as price_per_night,
-           hr.service_id AS hotel_service_id, 
+           hr.service_id AS hotel_service_id,
            s.name AS hotel_name
          FROM hotel_room_types hr
-         LEFT JOIN services s ON hr.service_id = s.id 
+         LEFT JOIN services s ON hr.service_id = s.id
          ORDER BY hr.created_at DESC
          LIMIT ? OFFSET ?`
       )
@@ -2075,7 +2075,7 @@ export class DatabaseService {
         `SELECT
            s.id, s.name, s.type, s.created_at, s.is_admin_approved, s.price, s.is_active
          FROM services s
-         WHERE s.type NOT IN ('hotel') 
+         WHERE s.type NOT IN ('hotel')
          ORDER BY s.created_at DESC
          LIMIT ? OFFSET ?`
       )


### PR DESCRIPTION
This commit addresses the issue where public-facing listing pages for hotels, activities, and other services were displaying items regardless of their admin approval status. Now, these pages will only show items that are marked as `is_admin_approved = 1` (in addition to typically also being `is_active = 1`).

Key Changes:

1.  **`DatabaseService` Updates (`src/lib/database.ts`):**
    *   Modified the `getAllHotels` and `countAllHotels` methods. Their SQL queries now include an `AND s.is_admin_approved = 1` condition to filter for approved hotels.

2.  **API Route Query Updates:**
    *   **`/api/activities/route.ts`:** The direct SQL query within the GET handler was updated to include `AND s.is_admin_approved = 1` in its WHERE clause.
    *   **`/api/services-main/route.ts`:** The direct SQL query within the GET handler was updated to include `AND s.is_admin_approved = 1` in its WHERE clause.

These changes ensure that only content vetted and approved by an administrator is visible on the public sections of the website, maintaining content quality and control. Admin-specific views (like the 'Manage Item Statuses' page and admin previews of detail pages) remain unaffected and continue to show items regardless of their approval status.