### PR TITLE
fix: Resolve 500 error when rejecting items in admin panel

### DIFF
--- a/src/app/(admin)/admin_approvals/page.tsx
+++ b/src/app/(admin)/admin_approvals/page.tsx
@@ -84,7 +84,7 @@ function AdminApprovalsContent() {
   ];
 
   // Renamed and hoisted function
-  const fetchAllItemsForStatusPage = async () => {
+  const fetchAllItemsForStatusPage = async () => { 
     setLoading(true);
     setError(null);
     try {
@@ -301,11 +301,11 @@ function AdminApprovalsContent() {
     }
     // Check if type starts with 'activity' (e.g., "activity/diving")
     // and normalize it to 'activity' for routing purposes.
-    if (item.type && item.type.startsWith('activity')) {
+    if (item.type && item.type.startsWith('activity')) { 
       return 'activity';
     }
     // For other specific types like 'rental', 'transport'
-    if (item.type) {
+    if (item.type) { 
       return item.type;
     }
     return 'item'; // Fallback

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
   console.log('🔍 [API] GET /api/activities: Request received');
   try {
     console.log('🔍 [API] GET /api/activities: Attempting database connection...');
-
+    
     // First check if database connection works
     let db;
     try {
@@ -36,9 +36,9 @@ export async function GET(request: Request) {
       console.error('❌ [API] GET /api/activities: Database connection failed:', dbError);
       throw new Error(`Database connection failed: ${dbError instanceof Error ? dbError.message : String(dbError)}`);
     }
-
+    
     // await the D1Database instance
-
+    
     const { searchParams } = new URL(request.url);
     console.log('🔍 [API] GET /api/activities: Request URL:', request.url);
 
@@ -88,7 +88,7 @@ export async function GET(request: Request) {
 
     const stmt = db.prepare(queryString).bind(...queryParams)
     console.log('🔍 [API] GET /api/activities: Executing query...');
-
+    
     let queryResult;
     try {
       queryResult = await stmt.all<Activity>();
@@ -97,7 +97,7 @@ export async function GET(request: Request) {
       console.error('❌ [API] GET /api/activities: Query execution failed:', queryError);
       throw new Error(`Query execution failed: ${queryError instanceof Error ? queryError.message : String(queryError)}`);
     }
-
+    
     const { results, success, error } = queryResult;
 
     console.log('🔍 [API] GET /api/activities: Query complete, success:', success);
@@ -109,7 +109,7 @@ export async function GET(request: Request) {
 
     const activitiesData = results ?? []
     console.log(`🔍 [API] GET /api/activities: Found ${activitiesData.length} activities`);
-
+    
     // Log each activity for debugging (limit to first 5 for brevity)
     const logLimit = Math.min(activitiesData.length, 5);
     for (let i = 0; i < logLimit; i++) {
@@ -124,13 +124,13 @@ export async function GET(request: Request) {
 
     if (activitiesData.length === 0) {
       console.warn('⚠️ [API] GET /api/activities: No activities found matching the criteria');
-
+      
       // Try a broader query to see if any services exist at all
       try {
         console.log('🔍 [API] GET /api/activities: Trying broader query to check if any services exist...');
         const checkServices = await db.prepare(`SELECT COUNT(*) as count FROM services`).first();
         console.log('🔍 [API] GET /api/activities: Services count:', checkServices);
-
+        
         if (checkServices && checkServices.count > 0) {
           console.log('🔍 [API] GET /api/activities: Services exist but no activities match the query criteria');
         } else {
@@ -159,10 +159,10 @@ export async function GET(request: Request) {
 
 
 export async function POST(request: NextRequest) {
-
+  
   console.warn("POST /api/activities is not fully implemented.");
    try {
-
+      
        return NextResponse.json({
            success: false, // Set to false as it's not implemented
            message: 'POST method for activities not implemented yet.',

--- a/src/app/api/admin/service_preview/[serviceId]/route.ts
+++ b/src/app/api/admin/service_preview/[serviceId]/route.ts
@@ -29,7 +29,7 @@ function parseStringList(value: string | null): string[] {
 function parseAmenities(amenitiesStr: string | null): any {
   if (!amenitiesStr) return { general: [], specifics: {} };
   try {
-    if ((amenitiesStr.trim().startsWith('{') && amenitiesStr.trim().endsWith('}')) ||
+    if ((amenitiesStr.trim().startsWith('{') && amenitiesStr.trim().endsWith('}')) || 
         (amenitiesStr.trim().startsWith('[') && amenitiesStr.trim().endsWith(']'))) {
       return JSON.parse(amenitiesStr);
     } else {
@@ -71,7 +71,7 @@ export async function GET(
       FROM services s
       LEFT JOIN islands i ON s.island_id = i.id  -- Changed to LEFT JOIN in case island_id is nullable or invalid temporarily
       LEFT JOIN service_providers sp ON s.provider_id = sp.id
-      WHERE s.id = ?
+      WHERE s.id = ? 
       AND (s.type LIKE 'transport%' OR s.type LIKE 'rental%' OR s.type LIKE 'activity%')
     `;
 
@@ -84,25 +84,25 @@ export async function GET(
         { status: 404 }
       );
     }
-
+    
     const parsedAmenities = parseAmenities(raw.amenities);
     const specificFields = parsedAmenities.specifics || {};
     const activitySpecifics = specificFields; // Assuming activity specifics might be directly under specifics
-
+    
     const locationDetails = specificFields.location_details || null;
     const whatToBring = specificFields.what_to_bring || [];
     const includedServices = specificFields.included_services || [];
     const notIncludedServices = specificFields.not_included_services || [];
     const latitude = specificFields.latitude ? parseFloat(specificFields.latitude) : null;
     const longitude = specificFields.longitude ? parseFloat(specificFields.longitude) : null;
-
+    
     const vehicleType = specificFields.vehicle_type || null;
     const capacityPassengers = specificFields.capacity_passengers ? parseInt(specificFields.capacity_passengers) : (specificFields.capacity ? parseInt(specificFields.capacity) : null);
     const routeDetails = specificFields.route_details || specificFields.route || null;
     const pricePerKm = specificFields.price_per_km ? parseFloat(specificFields.price_per_km) : null;
     const pricePerTrip = specificFields.price_per_trip ? parseFloat(specificFields.price_per_trip) : null;
     const driverIncluded = specificFields.driver_included === true;
-
+    
     const itemType = specificFields.item_type || null;
     const rentalDurationOptions = specificFields.rental_duration_options || [];
     const pricePerHour = specificFields.price_per_hour ? parseFloat(specificFields.price_per_hour) : null;
@@ -110,7 +110,7 @@ export async function GET(
     const depositAmount = specificFields.deposit?.amount ? parseFloat(specificFields.deposit.amount) : null;
     const pickupLocationOptions = specificFields.pickup_location_options || specificFields.pickup_locations || [];
     const rentalTerms = specificFields.rental_terms || specificFields.requirements?.details || null;
-
+    
     const providerInfo: ServiceProviderBasicInfo | undefined = raw.provider_business_name ? {
         id: raw.service_provider_table_id,
         business_name: raw.provider_business_name,

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1884,9 +1884,10 @@ export class DatabaseService {
    */
   async rejectHotel(serviceId: number, rejectReason: string = ''): Promise<D1Result> {
     const db = await getDatabase();
+    // admin_reject_reason column removed from query
     return db
-      .prepare('UPDATE services SET is_admin_approved = 0, admin_reject_reason = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND type = \'hotel\'')
-      .bind(rejectReason || null, serviceId)
+      .prepare('UPDATE services SET is_admin_approved = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND type = \'hotel\'')
+      .bind(serviceId) // rejectReason removed from bind
       .run();
   }
 
@@ -1898,9 +1899,10 @@ export class DatabaseService {
    */
   async rejectHotelRoom(roomTypeId: number, rejectReason: string = ''): Promise<D1Result> {
     const db = await getDatabase();
+    // admin_reject_reason column removed from query
     return db
-      .prepare('UPDATE hotel_room_types SET is_admin_approved = 0, admin_reject_reason = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
-      .bind(rejectReason || null, roomTypeId)
+      .prepare('UPDATE hotel_room_types SET is_admin_approved = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+      .bind(roomTypeId) // rejectReason removed from bind
       .run();
   }
 
@@ -1913,9 +1915,10 @@ export class DatabaseService {
   async rejectService(serviceId: number, rejectReason: string = ''): Promise<D1Result> {
     const db = await getDatabase();
     // This should not reject hotels through this generic service method.
+    // admin_reject_reason column removed from query
     return db
-      .prepare("UPDATE services SET is_admin_approved = 0, admin_reject_reason = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND type != 'hotel'")
-      .bind(rejectReason || null, serviceId)
+      .prepare("UPDATE services SET is_admin_approved = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND type != 'hotel'")
+      .bind(serviceId) // rejectReason removed from bind
       .run();
   }
 
@@ -2047,10 +2050,10 @@ export class DatabaseService {
       .prepare(
         `SELECT
            hr.id, hr.room_type, hr.created_at, hr.is_admin_approved, hr.base_price as price_per_night,
-           hr.service_id AS hotel_service_id,
+           hr.service_id AS hotel_service_id, 
            s.name AS hotel_name
          FROM hotel_room_types hr
-         LEFT JOIN services s ON hr.service_id = s.id
+         LEFT JOIN services s ON hr.service_id = s.id 
          ORDER BY hr.created_at DESC
          LIMIT ? OFFSET ?`
       )
@@ -2075,7 +2078,7 @@ export class DatabaseService {
         `SELECT
            s.id, s.name, s.type, s.created_at, s.is_admin_approved, s.price, s.is_active
          FROM services s
-         WHERE s.type NOT IN ('hotel')
+         WHERE s.type NOT IN ('hotel') 
          ORDER BY s.created_at DESC
          LIMIT ? OFFSET ?`
       )


### PR DESCRIPTION
This commit fixes a 500 Internal Server Error that occurred when an administrator attempted to reject a service, hotel, or hotel room from the 'Manage Item Statuses' page (`/admin/admin_approvals`).

The error was caused by the `DatabaseService` methods (`rejectHotel`, `rejectHotelRoom`, `rejectService`) attempting to update an `admin_reject_reason` column that does not exist in the `services` or `hotel_room_types` tables.

The correction involved modifying these three methods in `src/lib/database.ts`:
- Removed the `, admin_reject_reason = ?` part from their SQL UPDATE statements.
- Adjusted the `bind()` parameters for these statements accordingly by removing the `rejectReason` argument from the bind list.

The `rejectReason` parameter still exists in the method signatures to maintain the immediate API contract with the route handler, but it is currently not used in the database operation. If storing rejection reasons becomes a requirement, the `admin_reject_reason` column will need to be added to the relevant tables via a new database migration.

This fix ensures that rejecting an item now correctly sets its `is_admin_approved` status to `0` without causing a server error, allowing the admin status management page to function as intended.